### PR TITLE
Feature/sdcd 81

### DIFF
--- a/src/main/java/br/com/edu/ifmt/sacode/application/CategoriaRestAdapter.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/application/CategoriaRestAdapter.java
@@ -3,6 +3,7 @@ package br.com.edu.ifmt.sacode.application;
 import java.util.List;
 import java.util.UUID;
 
+import br.com.edu.ifmt.sacode.application.io.CategoriaResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,8 @@ import br.com.edu.ifmt.sacode.domain.entities.Categoria;
 import br.com.edu.ifmt.sacode.domain.entities.vo.Nome;
 import br.com.edu.ifmt.sacode.domain.services.CategoriaService;
 import br.com.edu.ifmt.sacode.domain.services.exception.CategoriaException;
+
+import static java.util.Objects.nonNull;
 
 @RestController
 @RequestMapping("/categoria")
@@ -66,12 +69,10 @@ public class CategoriaRestAdapter {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Categoria> buscarCategoriaPorId(@PathVariable Long id){
-        try {
-            return new ResponseEntity<>(categoriaService.buscarCategoria(UUID.fromString(String.valueOf(id))), HttpStatus.OK);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
+    public ResponseEntity<CategoriaResponse> buscarCategoriaPorId(@PathVariable String id) throws CategoriaException {
+        Categoria categoria = categoriaService.buscarCategoria(UUID.fromString(id));
+        return ResponseEntity.ok(new CategoriaResponse(categoria.getId().toString(), categoria.getUsuario().toString(), categoria.getNome().toString(),
+                categoria.getDescricao().toString(), nonNull(categoria.getIdCategoriaSuperior()) ? categoria.getIdCategoriaSuperior().toString() : null));
     }
 
     @GetMapping("/usuario/{id}")

--- a/src/main/java/br/com/edu/ifmt/sacode/application/configs/SecurityConfiguration.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/application/configs/SecurityConfiguration.java
@@ -36,7 +36,15 @@ public class SecurityConfiguration {
 
     public static final String [] ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED = {
             "/usuarios/login",
-            "/usuarios"
+            "/usuarios",
+            "/swagger-resources/**",
+            "/swagger-ui/**",
+            "/swagger-ui/index.html",
+            "/swagger-ui/index",
+            "/v3/api-docs/**",
+            "/v3/api-docs/",
+            "/swagger-ui.html",
+            "/webjars/**"
     };
 
     @Bean
@@ -44,7 +52,7 @@ public class SecurityConfiguration {
         return httpSecurity.csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and().authorizeHttpRequests()
-                .requestMatchers(HttpMethod.POST, SecurityConfiguration.ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED).permitAll()
+                .requestMatchers(SecurityConfiguration.ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED).permitAll()
                 .anyRequest().authenticated()
                 .and().exceptionHandling()
                 .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/br/com/edu/ifmt/sacode/application/interceptors/ExceptionInterceptor.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/application/interceptors/ExceptionInterceptor.java
@@ -1,6 +1,7 @@
 package br.com.edu.ifmt.sacode.application.interceptors;
 
 import br.com.edu.ifmt.sacode.domain.ports.LogPort;
+import br.com.edu.ifmt.sacode.domain.services.exception.CategoriaException;
 import br.com.edu.ifmt.sacode.domain.services.exception.UsuarioException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import jakarta.validation.ConstraintViolationException;
@@ -76,6 +77,11 @@ public class ExceptionInterceptor {
     public ResponseEntity<String> handleConstraintViolation(ConstraintViolationException ex) {
         String mensagem = "Erro de validação: " + ex.getMessage();
         return new ResponseEntity<>(mensagem, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CategoriaException.class)
+    public ResponseEntity<String> handleCategoriaException(CategoriaException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/java/br/com/edu/ifmt/sacode/application/interceptors/UserAuthenticationFilter.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/application/interceptors/UserAuthenticationFilter.java
@@ -68,6 +68,9 @@ public class UserAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean checkIfEndpointIsNotPublic(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
+        if (requestURI.contains("swagger") || requestURI.contains("api-docs")){
+            return false;
+        }
         return !Arrays.asList(SecurityConfiguration.ENDPOINTS_WITH_AUTHENTICATION_NOT_REQUIRED).contains(requestURI);
     }
 

--- a/src/main/java/br/com/edu/ifmt/sacode/application/io/CategoriaResponse.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/application/io/CategoriaResponse.java
@@ -1,0 +1,6 @@
+package br.com.edu.ifmt.sacode.application.io;
+
+
+
+public record CategoriaResponse(String id, String usuarioId, String nome, String descricao, String idCategoriaSuperior) {}
+

--- a/src/main/java/br/com/edu/ifmt/sacode/config/SwaggerConfig.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/config/SwaggerConfig.java
@@ -1,9 +1,12 @@
 package br.com.edu.ifmt.sacode.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +15,11 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
                 .info(new Info()
                         .title("Sacode")
                         .version("1.0.0")

--- a/src/main/java/br/com/edu/ifmt/sacode/infrastructure/mappers/CategoriaORMMapper.java
+++ b/src/main/java/br/com/edu/ifmt/sacode/infrastructure/mappers/CategoriaORMMapper.java
@@ -9,6 +9,7 @@ import br.com.edu.ifmt.sacode.infrastructure.persistence.UsuarioORM;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import static java.util.Objects.nonNull;
 
 public class CategoriaORMMapper {
 
@@ -35,7 +36,9 @@ public class CategoriaORMMapper {
         categoriaDominio.setId(UUID.fromString(categoriaORM.getIdCategoria()));
         categoriaDominio.setNome( new Nome(categoriaORM.getNome()));
         categoriaDominio.setDescricao(new Descricao(categoriaORM.getDescricao()));
-        categoriaDominio.setIdCategoriaSuperior(UUID.fromString(categoriaORM.getCategoriaSuperior()));
+        if(nonNull(categoriaORM.getCategoriaSuperior())){
+            categoriaDominio.setIdCategoriaSuperior(UUID.fromString(categoriaORM.getCategoriaSuperior()));
+        }
         categoriaDominio.setUsuario(UUID.fromString(categoriaORM.getUsuario().getIdUsuario()));
         return categoriaDominio;
     }


### PR DESCRIPTION
O código exibido mostra uma série de mudanças em um projeto Java. As alterações incluem ajustes em controladores, configurações de segurança e manipulação de exceções. Aqui está uma descrição das principais modificações:

### 1. Alteração em `CategoriaRestAdapter.java`
- **Importação de `CategoriaResponse`:** Agora, a classe `CategoriaRestAdapter` importa uma classe `CategoriaResponse`, que facilita o envio de respostas simplificadas nas APIs.
- **Mudança no método `buscarCategoriaPorId`:**
  - O método que antes retornava a entidade `Categoria` foi alterado para retornar um objeto `CategoriaResponse`, que contém apenas os dados essenciais da categoria.
  - Foi adicionada uma verificação para lidar com casos em que a `idCategoriaSuperior` pode ser nula.

### 2. Alteração em `SecurityConfiguration.java`
- **Adição de novos endpoints públicos:** Foram adicionados novos caminhos para documentação de API (Swagger e OpenAPI), que agora podem ser acessados sem autenticação.
- **Ajuste nas permissões:** As permissões foram configuradas para permitir acesso público a esses novos endpoints.

### 3. Alteração em `ExceptionInterceptor.java`
- **Tratamento de exceção `CategoriaException`:** Foi adicionado um novo método para capturar e tratar exceções do tipo `CategoriaException`, retornando uma resposta amigável ao cliente com o status `BAD_REQUEST`.

### 4. Alteração em `UserAuthenticationFilter.java`
- **Permissão para endpoints de documentação:** Foi adicionada uma verificação para que os endpoints relacionados à documentação (Swagger e API docs) sejam considerados públicos e não exijam autenticação.

### 5. Adição de `CategoriaResponse.java`
- **Nova classe `CategoriaResponse`:** Esta nova classe foi criada para representar uma resposta simples de uma categoria, contendo apenas os campos essenciais como `id`, `nome`, `descricao`, entre outros.

### 6. Alteração em `SwaggerConfig.java`
- **Configuração de segurança para Swagger:** Foram adicionadas configurações de segurança ao Swagger, permitindo autenticação JWT (JSON Web Token) nos endpoints protegidos.

### 7. Alteração em `CategoriaORMMapper.java`
- **Verificação de nulidade para `idCategoriaSuperior`:** Agora, ao mapear uma entidade de banco de dados para o modelo de domínio, há uma verificação que garante que `idCategoriaSuperior` só será setada se não for nula.
